### PR TITLE
feat: Kafka Consumer/Producer 설정을 위한 KafkaConfig 클래스 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // MySQL
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     implementation("jakarta.xml.bind:jakarta.xml.bind-api:4.0.0")

--- a/build.gradle
+++ b/build.gradle
@@ -24,14 +24,40 @@ repositories {
 }
 
 dependencies {
+    // Spring
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // Kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
+    // Lombok
     compileOnly 'org.projectlombok:lombok'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+    implementation("jakarta.xml.bind:jakarta.xml.bind-api:4.0.0")
+    implementation("org.glassfish.jaxb:jaxb-runtime:4.0.0")
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+
+    // TSID
+    implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.7.0'
+    implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
+
+    // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/opensource/alzheimerdinger/core/CoreApplication.java
+++ b/src/main/java/opensource/alzheimerdinger/core/CoreApplication.java
@@ -2,8 +2,10 @@ package opensource.alzheimerdinger.core;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class CoreApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/opensource/alzheimerdinger/core/domain/conversation/infra/kafka/config/KafkaConfig.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/conversation/infra/kafka/config/KafkaConfig.java
@@ -1,4 +1,0 @@
-package opensource.alzheimerdinger.core.domain.conversation.infra.kafka.config;
-
-public class KafkaConfig {
-}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/conversation/infra/kafka/config/KafkaConfig.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/conversation/infra/kafka/config/KafkaConfig.java
@@ -1,0 +1,4 @@
+package opensource.alzheimerdinger.core.domain.conversation.infra.kafka.config;
+
+public class KafkaConfig {
+}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/conversation/ui/ConversationController.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/conversation/ui/ConversationController.java
@@ -1,0 +1,4 @@
+package opensource.alzheimerdinger.core.domain.conversation.ui;
+
+public class ConversationController {
+}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/application/dto/request/LoginRequest.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/application/dto/request/LoginRequest.java
@@ -1,0 +1,9 @@
+package opensource.alzheimerdinger.core.domain.user.application.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest (
+        @Email @NotBlank String email,
+        @NotBlank String password
+) {}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/application/dto/request/SignUpRequest.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/application/dto/request/SignUpRequest.java
@@ -1,0 +1,12 @@
+package opensource.alzheimerdinger.core.domain.user.application.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import opensource.alzheimerdinger.core.domain.user.domain.entity.Role;
+
+public record SignUpRequest(
+        @Email @NotBlank String email,
+        @NotBlank String password,
+        @NotNull Role role
+) {}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/application/dto/response/LoginResponse.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/application/dto/response/LoginResponse.java
@@ -1,0 +1,6 @@
+package opensource.alzheimerdinger.core.domain.user.application.dto.response;
+
+public record LoginResponse(
+        String accessToken,
+        String refreshToken
+) {}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/application/request/SignUpRequest.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/application/request/SignUpRequest.java
@@ -1,0 +1,7 @@
+package opensource.alzheimerdinger.core.domain.user.application.request;
+
+public record SignUpRequest(
+        String email,
+        String password,
+        String role
+) {}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/application/request/SignUpRequest.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/application/request/SignUpRequest.java
@@ -1,7 +1,0 @@
-package opensource.alzheimerdinger.core.domain.user.application.request;
-
-public record SignUpRequest(
-        String email,
-        String password,
-        String role
-) {}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/application/usecase/UserAuthUseCase.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/application/usecase/UserAuthUseCase.java
@@ -1,0 +1,23 @@
+package opensource.alzheimerdinger.core.domain.user.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import opensource.alzheimerdinger.core.domain.user.application.request.SignUpRequest;
+import opensource.alzheimerdinger.core.domain.user.domain.service.UserService;
+import opensource.alzheimerdinger.core.global.exception.RestApiException;
+import org.springframework.stereotype.Service;
+
+import static opensource.alzheimerdinger.core.global.exception.code.status.GlobalErrorStatus._EXIST_ENTITY;
+
+@Service
+@RequiredArgsConstructor
+public class UserAuthUseCase {
+
+    private final UserService userService;
+
+    public void signUp(SignUpRequest request) {
+        if (userService.isAlreadyRegistered(request.email()))
+            throw new RestApiException(_EXIST_ENTITY);
+
+        userService.signUp(request);
+    }
+}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/application/usecase/UserAuthUseCase.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/application/usecase/UserAuthUseCase.java
@@ -1,23 +1,43 @@
 package opensource.alzheimerdinger.core.domain.user.application.usecase;
 
 import lombok.RequiredArgsConstructor;
-import opensource.alzheimerdinger.core.domain.user.application.request.SignUpRequest;
+import opensource.alzheimerdinger.core.domain.user.application.dto.request.LoginRequest;
+import opensource.alzheimerdinger.core.domain.user.application.dto.request.SignUpRequest;
+import opensource.alzheimerdinger.core.domain.user.application.dto.response.LoginResponse;
+import opensource.alzheimerdinger.core.domain.user.domain.entity.User;
 import opensource.alzheimerdinger.core.domain.user.domain.service.UserService;
 import opensource.alzheimerdinger.core.global.exception.RestApiException;
+import opensource.alzheimerdinger.core.global.security.TokenProvider;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import static opensource.alzheimerdinger.core.global.exception.code.status.GlobalErrorStatus._EXIST_ENTITY;
+import static opensource.alzheimerdinger.core.global.exception.code.status.AuthErrorStatus.ALREADY_REGISTERED_EMAIL;
+import static opensource.alzheimerdinger.core.global.exception.code.status.AuthErrorStatus.LOGIN_ERROR;
 
 @Service
 @RequiredArgsConstructor
 public class UserAuthUseCase {
 
     private final UserService userService;
+    private final PasswordEncoder passwordEncoder;
+    private final TokenProvider tokenProvider;
 
     public void signUp(SignUpRequest request) {
         if (userService.isAlreadyRegistered(request.email()))
-            throw new RestApiException(_EXIST_ENTITY);
+            throw new RestApiException(ALREADY_REGISTERED_EMAIL);
 
         userService.signUp(request);
+    }
+
+    public LoginResponse login(LoginRequest request) {
+        User user = userService.findByEmail(request.email());
+
+        if (!passwordEncoder.matches(request.password(), user.getPassword()))
+            throw new RestApiException(LOGIN_ERROR);
+
+        String accessToken = tokenProvider.createAccessToken(user.getUserId(), user.getRole());
+        String refreshToken = tokenProvider.createRefreshToken(user.getUserId(), user.getRole());
+
+        return new LoginResponse(accessToken, refreshToken);
     }
 }

--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/domain/entity/Role.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/domain/entity/Role.java
@@ -1,0 +1,6 @@
+package opensource.alzheimerdinger.core.domain.user.domain.entity;
+
+public enum Role {
+    ROLE_GUARDIAN,
+    ROLE_PATIENT
+}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/domain/entity/User.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/domain/entity/User.java
@@ -7,9 +7,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @Table(name = "users")
 @AllArgsConstructor
 @NoArgsConstructor
@@ -25,5 +27,5 @@ public class User {
     @Column(nullable = false)
     private String password;
 
-    private Role role
+    private Role role;
 }

--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/domain/entity/User.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/domain/entity/User.java
@@ -1,0 +1,29 @@
+package opensource.alzheimerdinger.core.domain.user.domain.entity;
+
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class User {
+
+    @Id @Tsid
+    private String userId;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    private Role role
+}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/domain/repository/UserRepository.java
@@ -5,9 +5,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, String> {
 
     @Query("select count(u) > 0 from User u where u.email = :email")
     Boolean existsByEmail(@Param("email") String email);
 
+    @Query("select u from User u where u.email = :email")
+    Optional<User> findByEmail(@Param("email") String email);
 }

--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/domain/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package opensource.alzheimerdinger.core.domain.user.domain.repository;
+
+import opensource.alzheimerdinger.core.domain.user.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface UserRepository extends JpaRepository<User, String> {
+
+    @Query("select count(u) > 0 from User u where u.email = :email")
+    Boolean existsByEmail(@Param("email") String email);
+
+}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/domain/service/UserService.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/domain/service/UserService.java
@@ -1,0 +1,27 @@
+package opensource.alzheimerdinger.core.domain.user.domain.service;
+
+import lombok.RequiredArgsConstructor;
+import opensource.alzheimerdinger.core.domain.user.application.request.SignUpRequest;
+import opensource.alzheimerdinger.core.domain.user.domain.entity.User;
+import opensource.alzheimerdinger.core.domain.user.domain.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public boolean isAlreadyRegistered(String email) {
+        return userRepository.existsByEmail(email);
+    }
+
+    public void signUp(SignUpRequest request) {
+        userRepository.save(
+                User.builder()
+                        .email(request.email())
+                        .password()
+                        .role(request.role())
+        );
+    }
+}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/domain/service/UserService.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/domain/service/UserService.java
@@ -1,16 +1,27 @@
 package opensource.alzheimerdinger.core.domain.user.domain.service;
 
 import lombok.RequiredArgsConstructor;
-import opensource.alzheimerdinger.core.domain.user.application.request.SignUpRequest;
+import opensource.alzheimerdinger.core.domain.user.application.dto.request.LoginRequest;
+import opensource.alzheimerdinger.core.domain.user.application.dto.request.SignUpRequest;
 import opensource.alzheimerdinger.core.domain.user.domain.entity.User;
 import opensource.alzheimerdinger.core.domain.user.domain.repository.UserRepository;
+import opensource.alzheimerdinger.core.global.exception.RestApiException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import static opensource.alzheimerdinger.core.global.exception.code.status.GlobalErrorStatus._NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public User findByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new RestApiException(_NOT_FOUND));
+    }
 
     public boolean isAlreadyRegistered(String email) {
         return userRepository.existsByEmail(email);
@@ -20,8 +31,9 @@ public class UserService {
         userRepository.save(
                 User.builder()
                         .email(request.email())
-                        .password()
+                        .password(passwordEncoder.encode(request.password()))
                         .role(request.role())
+                        .build()
         );
     }
 }

--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/ui/AuthController.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/ui/AuthController.java
@@ -1,12 +1,13 @@
 package opensource.alzheimerdinger.core.domain.user.ui;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import opensource.alzheimerdinger.core.domain.user.application.request.SignUpRequest;
+import opensource.alzheimerdinger.core.domain.user.application.dto.request.LoginRequest;
+import opensource.alzheimerdinger.core.domain.user.application.dto.request.SignUpRequest;
+import opensource.alzheimerdinger.core.domain.user.application.dto.response.LoginResponse;
 import opensource.alzheimerdinger.core.domain.user.application.usecase.UserAuthUseCase;
 import opensource.alzheimerdinger.core.global.common.BaseResponse;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,8 +17,18 @@ public class AuthController {
     private final UserAuthUseCase userAuthUseCase;
 
     @PostMapping("/sign-up")
-    public BaseResponse<Void> signUp(SignUpRequest request) {
+    public BaseResponse<Void> signUp(@RequestBody @Valid SignUpRequest request) {
         userAuthUseCase.signUp(request);
+        return BaseResponse.onSuccess();
+    }
+
+    @PostMapping("/login")
+    public BaseResponse<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
+        return BaseResponse.onSuccess(userAuthUseCase.login(request));
+    }
+
+    @GetMapping("/test")
+    public BaseResponse<Void> test() {
         return BaseResponse.onSuccess();
     }
 }

--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/ui/AuthController.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/ui/AuthController.java
@@ -1,0 +1,23 @@
+package opensource.alzheimerdinger.core.domain.user.ui;
+
+import lombok.RequiredArgsConstructor;
+import opensource.alzheimerdinger.core.domain.user.application.request.SignUpRequest;
+import opensource.alzheimerdinger.core.domain.user.application.usecase.UserAuthUseCase;
+import opensource.alzheimerdinger.core.global.common.BaseResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class AuthController {
+
+    private final UserAuthUseCase userAuthUseCase;
+
+    @PostMapping("/sign-up")
+    public BaseResponse<Void> signUp(SignUpRequest request) {
+        userAuthUseCase.signUp(request);
+        return BaseResponse.onSuccess();
+    }
+}

--- a/src/main/java/opensource/alzheimerdinger/core/global/config/KafkaConfig.java
+++ b/src/main/java/opensource/alzheimerdinger/core/global/config/KafkaConfig.java
@@ -1,0 +1,57 @@
+package opensource.alzheimerdinger.core.global.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaConfig {
+
+    // Consumer Config
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
+        properties.put(ConsumerConfig.GROUP_ID_CONFIG, "consumerGroupId");
+        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+        return new DefaultKafkaConsumerFactory<>(properties);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory
+                = new ConcurrentKafkaListenerContainerFactory<>();
+        kafkaListenerContainerFactory.setConsumerFactory(consumerFactory());
+
+        return kafkaListenerContainerFactory;
+    }
+
+    // Producer Config
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "127.0.0.1:9092");
+        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+        return new DefaultKafkaProducerFactory<>(properties);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+}

--- a/src/main/java/opensource/alzheimerdinger/core/global/config/SecurityConfig.java
+++ b/src/main/java/opensource/alzheimerdinger/core/global/config/SecurityConfig.java
@@ -1,0 +1,71 @@
+package opensource.alzheimerdinger.core.global.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import opensource.alzheimerdinger.core.global.security.ExcludeAuthPathProperties;
+import opensource.alzheimerdinger.core.global.security.JwtAuthenticationFilter;
+import opensource.alzheimerdinger.core.global.security.TokenProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Slf4j
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final TokenProvider tokenProvider;
+    private final ExcludeAuthPathProperties excludeAuthPathProperties;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http.csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable);
+
+        http.authorizeHttpRequests(request -> {
+            excludeAuthPathProperties.getPaths().iterator()
+                    .forEachRemaining(authPath ->
+                            request.requestMatchers(HttpMethod.valueOf(authPath.getMethod()), authPath.getPathPattern()).permitAll()
+                    );
+        });
+
+        http.authorizeHttpRequests(request -> request
+                .requestMatchers(HttpMethod.POST, "/users/token").hasRole("USER") // 토큰 재발급
+                // Authenticated
+                .anyRequest().authenticated()
+        );
+
+        // Session 해제
+        http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        // Jwt 커스텀 필터 등록
+        http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+        // Token Exception Handling
+        http.exceptionHandling(except -> except
+                .authenticationEntryPoint((request, response, authException) -> response.sendError(response.getStatus(), "토큰 오류"))
+        );
+
+        return http.build();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(tokenProvider, excludeAuthPathProperties);
+    }
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/opensource/alzheimerdinger/core/global/exception/code/status/AuthErrorStatus.java
+++ b/src/main/java/opensource/alzheimerdinger/core/global/exception/code/status/AuthErrorStatus.java
@@ -18,7 +18,9 @@ public enum AuthErrorStatus implements BaseCodeInterface {
     EXPIRED_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "AUTH005", "만료된 REFRESH TOKEN입니다."),
     INVALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "AUTH005", "유효하지 않은 ACCESS TOKEN입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "AUTH006", "유효하지 않은 REFRESH TOKEN입니다."),
-    FAILED_SOCIAL_LOGIN(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH007", "소셜 로그인에 실패하였습니다.")
+    FAILED_SOCIAL_LOGIN(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH007", "소셜 로그인에 실패하였습니다."),
+    LOGIN_ERROR(HttpStatus.BAD_REQUEST, "AUTH008", "잘못된 아이디 혹은 비밀번호입니다."),
+    ALREADY_REGISTERED_EMAIL(HttpStatus.BAD_REQUEST, "AUTH009", "이미 가입된 이메일입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/opensource/alzheimerdinger/core/global/exception/code/status/GlobalErrorStatus.java
+++ b/src/main/java/opensource/alzheimerdinger/core/global/exception/code/status/GlobalErrorStatus.java
@@ -17,8 +17,6 @@ public enum GlobalErrorStatus implements BaseCodeInterface {
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
     _NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "요청한 정보를 찾을 수 없습니다."),
     _METHOD_ARGUMENT_ERROR(HttpStatus.BAD_REQUEST, "COMMON405", "Argument Type이 올바르지 않습니다."),
-    _CLIENT_ONLY_ERROR(HttpStatus.BAD_REQUEST, "COMMON406", "client만 접근 가능합니다."),
-    _EXPERT_ONLY_ERROR(HttpStatus.BAD_REQUEST, "COMMON407", "exeprt만 접근 가능합니다."),
     _CONTAIN_BAD_WORD(HttpStatus.BAD_REQUEST, "COMMON400", "입력하신 내용에 부적절한 단어가 포함되어 있습니다."),
     _EXIST_ENTITY(HttpStatus.BAD_REQUEST, "COMMON400", "이미 존재하는 요청입니다."),
     _TOO_MANY_REQUEST(HttpStatus.TOO_MANY_REQUESTS, "COMMON429", "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요."),

--- a/src/main/java/opensource/alzheimerdinger/core/global/security/ExcludeAuthPathProperties.java
+++ b/src/main/java/opensource/alzheimerdinger/core/global/security/ExcludeAuthPathProperties.java
@@ -1,0 +1,25 @@
+package opensource.alzheimerdinger.core.global.security;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@ConfigurationProperties("exclude-auth-path-patterns")
+public class ExcludeAuthPathProperties {
+    private List<AuthPath> paths;
+
+    public List<String> getExcludeAuthPaths() {
+        return paths.stream().map(AuthPath::getPathPattern).toList();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class AuthPath {
+        private String pathPattern;
+        private String method;
+    }
+}

--- a/src/main/java/opensource/alzheimerdinger/core/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/opensource/alzheimerdinger/core/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,79 @@
+package opensource.alzheimerdinger.core.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import opensource.alzheimerdinger.core.global.exception.RestApiException;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.server.PathContainer;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.pattern.PathPatternParser;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import static opensource.alzheimerdinger.core.global.exception.code.status.AuthErrorStatus.EMPTY_JWT;
+import static opensource.alzheimerdinger.core.global.exception.code.status.AuthErrorStatus.INVALID_ACCESS_TOKEN;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final TokenProvider tokenProvider;
+    private final ExcludeAuthPathProperties excludeAuthPathProperties;
+
+    private static final PathPatternParser pathPatternParser = new PathPatternParser();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            if (isExcludedPath(request)) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            tokenProvider.getToken(request).ifPresentOrElse(token -> {
+                if (tokenProvider.validateToken(token))
+                    // todo: Access & Refresh 구분
+                    setAuthentication(token);
+                else throw new RestApiException(INVALID_ACCESS_TOKEN);
+            },()-> {
+                throw new RestApiException(EMPTY_JWT);
+            });
+
+            filterChain.doFilter(request, response);
+        } catch (RestApiException e) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json;charset=UTF-8");
+
+            String jsonResponse = String.format("{\"message\": \"%s\"}", e.getMessage());
+
+            PrintWriter writer = response.getWriter();
+            writer.write(jsonResponse);
+            writer.flush();
+            writer.close();
+        }
+    }
+
+    public boolean isExcludedPath(HttpServletRequest request) {
+        String requestPath = request.getRequestURI();
+        HttpMethod requestMethod = HttpMethod.valueOf(request.getMethod());
+
+        return excludeAuthPathProperties.getPaths().stream()
+                .anyMatch(authPath ->
+                        pathPatternParser.parse(authPath.getPathPattern())
+                                .matches(PathContainer.parsePath(requestPath))
+                        && requestMethod.equals(HttpMethod.valueOf(authPath.getMethod()))
+                );
+    }
+
+    private void setAuthentication(String token) {
+        if (tokenProvider.validateToken(token)) {
+            Authentication authentication = tokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+    }
+}

--- a/src/main/java/opensource/alzheimerdinger/core/global/security/JwtProperties.java
+++ b/src/main/java/opensource/alzheimerdinger/core/global/security/JwtProperties.java
@@ -1,0 +1,17 @@
+package opensource.alzheimerdinger.core.global.security;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Setter
+@Getter
+@Component
+public class JwtProperties {
+    @Value("${jwt.key}")
+    private String key;
+
+    @Value("${jwt.access.expiration}")
+    private Long accessTokenExpirationPeriodDay;
+}

--- a/src/main/java/opensource/alzheimerdinger/core/global/security/TokenProvider.java
+++ b/src/main/java/opensource/alzheimerdinger/core/global/security/TokenProvider.java
@@ -7,6 +7,7 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import opensource.alzheimerdinger.core.domain.user.domain.entity.Role;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -35,7 +36,7 @@ public class TokenProvider {
     private static final String ID_CLAIM = "id";
     private static final String ROLE_CLAIM = "role";
 
-    public String createAccessToken(String id) {    // todo: param Role
+    public String createAccessToken(String id, Role role) {    // todo: param Role
         Date now = new Date();
         return Jwts.builder()
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
@@ -48,12 +49,12 @@ public class TokenProvider {
                 ))
                 .setSubject(ACCESS_TOKEN_SUBJECT)
                 .claim(ID_CLAIM, id)
-                .claim(ROLE_CLAIM, "ROLE_USER")
+                .claim(ROLE_CLAIM, role)
                 .signWith(Keys.hmacShaKeyFor(jwtProperties.getKey().getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS256)
                 .compact();
     }
 
-    public String createRefreshToken(String id) {
+    public String createRefreshToken(String id, Role role) {
         Date now = new Date();
         return Jwts.builder()
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
@@ -66,7 +67,7 @@ public class TokenProvider {
                 ))
                 .setSubject(REFRESH_TOKEN_SUBJECT)
                 .claim(ID_CLAIM, id)
-                .claim(ROLE_CLAIM, "ROLE_USER")
+                .claim(ROLE_CLAIM, role)
                 .signWith(Keys.hmacShaKeyFor(jwtProperties.getKey().getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS256)
                 .compact();
     }
@@ -91,6 +92,14 @@ public class TokenProvider {
     public Optional<String> getId(String token) {
         try {
             return Optional.ofNullable(getClaims(token).get(ID_CLAIM, String.class));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    public Optional<Role> getRole(String token) {
+        try {
+            return Optional.ofNullable(getClaims(token).get(ROLE_CLAIM, Role.class));
         } catch (Exception e) {
             return Optional.empty();
         }

--- a/src/main/java/opensource/alzheimerdinger/core/global/security/TokenProvider.java
+++ b/src/main/java/opensource/alzheimerdinger/core/global/security/TokenProvider.java
@@ -1,0 +1,111 @@
+package opensource.alzheimerdinger.core.global.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Optional;
+import java.util.Set;
+
+
+@Service
+@RequiredArgsConstructor
+public class TokenProvider {
+
+    private final JwtProperties jwtProperties;
+
+    private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
+    private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
+    private static final String TOKEN_HEADER = "Authorization";
+    private static final String BEARER = "Bearer ";
+    private static final String ID_CLAIM = "id";
+    private static final String ROLE_CLAIM = "role";
+
+    public String createAccessToken(String id) {    // todo: param Role
+        Date now = new Date();
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setIssuedAt(now)
+                .setExpiration(Date.from(
+                        LocalDateTime.now()
+                                .plusDays(jwtProperties.getAccessTokenExpirationPeriodDay())
+                                .atZone(ZoneId.of("Asia/Seoul"))
+                                .toInstant()
+                ))
+                .setSubject(ACCESS_TOKEN_SUBJECT)
+                .claim(ID_CLAIM, id)
+                .claim(ROLE_CLAIM, "ROLE_USER")
+                .signWith(Keys.hmacShaKeyFor(jwtProperties.getKey().getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String createRefreshToken(String id) {
+        Date now = new Date();
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setIssuedAt(now)
+                .setExpiration(Date.from(
+                        LocalDateTime.now()
+                                .plusDays(jwtProperties.getAccessTokenExpirationPeriodDay())
+                                .atZone(ZoneId.of("Asia/Seoul"))
+                                .toInstant()
+                ))
+                .setSubject(REFRESH_TOKEN_SUBJECT)
+                .claim(ID_CLAIM, id)
+                .claim(ROLE_CLAIM, "ROLE_USER")
+                .signWith(Keys.hmacShaKeyFor(jwtProperties.getKey().getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public Boolean validateToken(String jwtToken) {
+        try {
+            Jwts.parserBuilder().setSigningKey(Keys.hmacShaKeyFor(jwtProperties.getKey().getBytes(StandardCharsets.UTF_8)))
+                    .build()
+                    .parseClaimsJws(jwtToken);  // Decode
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = getClaims(token);
+        Set<SimpleGrantedAuthority> authorities = Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"));
+        return new UsernamePasswordAuthenticationToken(new User(claims.get(ID_CLAIM, String.class), "", authorities), token, authorities);
+    }
+
+    public Optional<String> getId(String token) {
+        try {
+            return Optional.ofNullable(getClaims(token).get(ID_CLAIM, String.class));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    public Optional<String> getToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(TOKEN_HEADER))
+                .filter(refreshToken -> refreshToken.startsWith(BEARER))
+                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parserBuilder().setSigningKey(Keys.hmacShaKeyFor(jwtProperties.getKey().getBytes(StandardCharsets.UTF_8)))
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=core

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,20 @@
+spring:
+  datasource:
+    username: ${USERNAME}
+    url: ${URL}
+    password: ${password}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    open-in-view: false
+
+
 jwt:
-  key: jhqwlekfjnasu23fjknsp8vne14sgd
+  key: fdsafdsafdsafdsafdsafdsafdsafdsafdsafdsafda
   access:
     expiration: 360000
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+jwt:
+  key: jhqwlekfjnasu23fjknsp8vne14sgd
+  access:
+    expiration: 360000
+
+exclude-auth-path-patterns:
+  paths:
+    - path-pattern: /api/users/sign-up
+      method: POST
+    - path-pattern: /api/users/login
+      method: POST


### PR DESCRIPTION
# PR 요약
KafkaConfig 클래스 추가를 통해 Spring Kafka Consumer/Producer 설정 환경을 구축.

# PR 상세 내용
1. Consumer 설정
- ConsumerFactory<String, String> 빈 등록 (bootstrap 서버, 그룹 ID, Deserializer)
- ConcurrentKafkaListenerContainerFactory<String, String> 빈 등록

2. Producer 설정
- ProducerFactory<String, String> 빈 등록 (bootstrap 서버, Serializer)
- KafkaTemplate<String, String> 빈 등록

# 주의 사항
- Consumer와 Producer의 BOOTSTRAP_SERVERS_CONFIG 주소(kafka:9092 vs 127.0.0.1:9092)를 운영 환경에 맞게 통일해야 함.
- Group ID, 토픽 이름 등 주요 설정은 application.yml 또는 환경 변수로 외부화할 것.
- 로컬 테스트 시 Docker-Compose Kafka 환경을 미리 띄워야 함.

# 체크 리스트
- [ ] KafkaConfig 빈이 Spring Context에 정상 등록되었는지 확인
- [ ] @KafkaListener를 활용한 메시지 수신 테스트 완료
- [ ] KafkaTemplate을 활용한 메시지 발행 테스트 완료
- [ ] application.yml 환경 변수가 올바르게 적용되었는지 검증