### PR TITLE
feat: Analysis Kafka Consumer 구현 및 RDB 저장

### DIFF
--- a/src/main/java/opensource/alzheimerdinger/core/domain/analysis/application/dto/request/CognitiveReportRequest.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/analysis/application/dto/request/CognitiveReportRequest.java
@@ -1,0 +1,16 @@
+package opensource.alzheimerdinger.core.domain.analysis.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class CognitiveReportRequest {
+    @NotBlank private String reportId;
+    @NotBlank private String sessionId;
+    @NotBlank private Integer riskScore;
+    @NotBlank private String riskLevel;
+    @NotBlank private String interpretation;
+    @NotBlank private LocalDateTime createdAt;
+}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/analysis/application/dto/request/EmotionAnalysisRequest.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/analysis/application/dto/request/EmotionAnalysisRequest.java
@@ -1,0 +1,15 @@
+package opensource.alzheimerdinger.core.domain.analysis.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class EmotionAnalysisRequest {
+    @NotBlank private String analysisId;
+    @NotBlank private String sessionId;
+    @NotBlank private LocalDateTime analysisTime;
+    @NotBlank private String emotionLabel;
+    @NotBlank private Float emotionScore;
+}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/analysis/domain/entity/CognitiveReport.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/analysis/domain/entity/CognitiveReport.java
@@ -1,0 +1,37 @@
+package opensource.alzheimerdinger.core.domain.analysis.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "cognitive_reports",
+        indexes = {@Index(name = "idx_report_session", columnList = "session_id")})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CognitiveReport {
+    @Id
+    @Column(name = "report_id", length = 36)
+    private String reportId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_report_session"))
+    private ConversationSession session;
+
+    @Column(name = "risk_score", nullable = false)
+    private Integer riskScore;
+
+    @Column(name = "risk_level", length = 10, nullable = false)
+    private String riskLevel;  // LOW, MEDIUM, HIGH
+
+    @Column(name = "interpretation", length = 255, nullable = false)
+    private String interpretation;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/analysis/domain/entity/ConversationSession.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/analysis/domain/entity/ConversationSession.java
@@ -1,0 +1,34 @@
+package opensource.alzheimerdinger.core.domain.analysis.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "conversation_sessions")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ConversationSession {
+    @Id
+    @Column(name = "session_id", length = 36)
+    private String sessionId;
+
+    @Column(name = "user_id", length = 36, nullable = false)
+    private String userId;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalDateTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalDateTime endTime;
+
+    @Column(name = "session_seq", nullable = false)
+    private Integer sessionSeq;
+}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/analysis/domain/entity/EmotionAnalysis.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/analysis/domain/entity/EmotionAnalysis.java
@@ -1,0 +1,34 @@
+package opensource.alzheimerdinger.core.domain.analysis.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "emotion_analysis",
+        indexes = {@Index(name = "idx_emotion_session", columnList = "session_id")})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EmotionAnalysis {
+    @Id
+    @Column(name = "analysis_id", length = 36)
+    private String analysisId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_emotion_session"))
+    private ConversationSession session;
+
+    @Column(name = "analysis_time", nullable = false)
+    private LocalDateTime analysisTime;
+
+    @Column(name = "emotion_label", length = 50, nullable = false)
+    private String emotionLabel;
+
+    @Column(name = "emotion_score", nullable = false)
+    private Float emotionScore;
+}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/analysis/domain/repository/CognitiveReportRepository.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/analysis/domain/repository/CognitiveReportRepository.java
@@ -1,0 +1,12 @@
+package opensource.alzheimerdinger.core.domain.analysis.domain.repository;
+
+
+import opensource.alzheimerdinger.core.domain.analysis.domain.entity.CognitiveReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CognitiveReportRepository
+        extends JpaRepository<CognitiveReport, String> {
+    List<CognitiveReport> findBySession_SessionId(String sessionId);
+}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/analysis/domain/repository/ConversationSessionRepository.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/analysis/domain/repository/ConversationSessionRepository.java
@@ -1,0 +1,6 @@
+package opensource.alzheimerdinger.core.domain.analysis.domain.repository;
+
+import opensource.alzheimerdinger.core.domain.analysis.domain.entity.ConversationSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ConversationSessionRepository extends JpaRepository<ConversationSession, String> {}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/analysis/domain/repository/EmotionAnalysisRepository.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/analysis/domain/repository/EmotionAnalysisRepository.java
@@ -1,0 +1,11 @@
+package opensource.alzheimerdinger.core.domain.analysis.domain.repository;
+
+import opensource.alzheimerdinger.core.domain.analysis.domain.entity.EmotionAnalysis;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface EmotionAnalysisRepository
+        extends JpaRepository<EmotionAnalysis, String> {
+    List<EmotionAnalysis> findBySession_SessionId(String sessionId);
+}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/analysis/domain/service/CognitiveReportService.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/analysis/domain/service/CognitiveReportService.java
@@ -1,0 +1,31 @@
+package opensource.alzheimerdinger.core.domain.analysis.domain.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import opensource.alzheimerdinger.core.domain.analysis.application.dto.request.CognitiveReportRequest;
+import opensource.alzheimerdinger.core.domain.analysis.domain.entity.CognitiveReport;
+import opensource.alzheimerdinger.core.domain.analysis.domain.repository.CognitiveReportRepository;
+import opensource.alzheimerdinger.core.domain.analysis.domain.repository.ConversationSessionRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CognitiveReportService {
+    private final ConversationSessionRepository sessionRepo;
+    private final CognitiveReportRepository reportRepo;
+
+    @Transactional
+    public void saveCognitiveReport(CognitiveReportRequest dto) {
+        var session = sessionRepo.findById(dto.getSessionId())
+                .orElseThrow(() -> new IllegalArgumentException("Invalid session"));
+        var entity = CognitiveReport.builder()
+                .reportId(dto.getReportId())
+                .session(session)
+                .riskScore(dto.getRiskScore())
+                .riskLevel(dto.getRiskLevel())
+                .interpretation(dto.getInterpretation())
+                .createdAt(dto.getCreatedAt())
+                .build();
+        reportRepo.save(entity);
+    }
+}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/analysis/domain/service/EmotionAnalysisService.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/analysis/domain/service/EmotionAnalysisService.java
@@ -1,0 +1,30 @@
+package opensource.alzheimerdinger.core.domain.analysis.domain.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import opensource.alzheimerdinger.core.domain.analysis.application.dto.request.EmotionAnalysisRequest;
+import opensource.alzheimerdinger.core.domain.analysis.domain.entity.EmotionAnalysis;
+import opensource.alzheimerdinger.core.domain.analysis.domain.repository.ConversationSessionRepository;
+import opensource.alzheimerdinger.core.domain.analysis.domain.repository.EmotionAnalysisRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmotionAnalysisService {
+    private final ConversationSessionRepository sessionRepo;
+    private final EmotionAnalysisRepository analysisRepo;
+
+    @Transactional
+    public void saveEmotionAnalysis(EmotionAnalysisRequest dto) {
+        var session = sessionRepo.findById(dto.getSessionId())
+                .orElseThrow(() -> new IllegalArgumentException("Invalid session"));
+        var entity = EmotionAnalysis.builder()
+                .analysisId(dto.getAnalysisId())
+                .session(session)
+                .analysisTime(dto.getAnalysisTime())
+                .emotionLabel(dto.getEmotionLabel())
+                .emotionScore(dto.getEmotionScore())
+                .build();
+        analysisRepo.save(entity);
+    }
+}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/analysis/infra/kafka/consumer/CognitiveReportConsumer.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/analysis/infra/kafka/consumer/CognitiveReportConsumer.java
@@ -1,0 +1,31 @@
+package opensource.alzheimerdinger.core.domain.analysis.infra.kafka.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import opensource.alzheimerdinger.core.domain.analysis.application.dto.request.CognitiveReportRequest;
+import opensource.alzheimerdinger.core.domain.analysis.domain.service.CognitiveReportService;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CognitiveReportConsumer {
+    private final ObjectMapper objectMapper;
+    private final CognitiveReportService reportService;
+
+    @KafkaListener(
+            topics = "${spring.kafka.topics.cognitive-report}",
+            groupId = "${spring.kafka.consumer.group-id}"
+    )
+    public void listen(@Payload String message) {
+        try {
+            CognitiveReportRequest dto = objectMapper.readValue(message, CognitiveReportRequest.class);
+            reportService.saveCognitiveReport(dto);
+        } catch (Exception e) {
+            log.error("Failed processing cognitive-report message", e);
+        }
+    }
+}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/analysis/infra/kafka/consumer/EmotionAnalysisConsumer.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/analysis/infra/kafka/consumer/EmotionAnalysisConsumer.java
@@ -1,0 +1,31 @@
+package opensource.alzheimerdinger.core.domain.analysis.infra.kafka.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import opensource.alzheimerdinger.core.domain.analysis.application.dto.request.EmotionAnalysisRequest;
+import opensource.alzheimerdinger.core.domain.analysis.domain.service.EmotionAnalysisService;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EmotionAnalysisConsumer {
+    private final ObjectMapper objectMapper;
+    private final EmotionAnalysisService analysisService;
+
+    @KafkaListener(
+            topics = "${spring.kafka.topics.emotion-analysis}",
+            groupId = "${spring.kafka.consumer.group-id}"
+    )
+    public void listen(@Payload String message) {
+        try {
+            EmotionAnalysisRequest dto = objectMapper.readValue(message, EmotionAnalysisRequest.class);
+            analysisService.saveEmotionAnalysis(dto);
+        } catch (Exception e) {
+            log.error("Failed processing emotion-analysis message", e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,10 +20,18 @@ spring:
 
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+
     consumer:
       group-id: ${KAFKA_CONSUMER_GROUP:transcript-consumer-group}
+    analysis-group:
+      group-id: ${KAFKA_CONSUMER_ANALYSIS_GROUP:analysis-consumer-group}
+    cognitive-group:
+      group-id: ${KAFKA_CONSUMER_COGNITIVE_GROUP:cognitive-consumer-group}
+
     topics:
       transcript: ${KAFKA_TOPIC_TRANSCRIPT:ai-transcript}
+      emotion-analysis: ${KAFKA_TOPIC_EMOTION_ANALYSIS:emotion-analysis}
+      cognitive-report: ${KAFKA_TOPIC_COGNITIVE_REPORT:cognitive-report}
 
 
 jwt:

--- a/src/test/java/opensource/alzheimerdinger/core/domain/analysis/infra/kafka/consumer/CognitiveReportConsumerTest.java
+++ b/src/test/java/opensource/alzheimerdinger/core/domain/analysis/infra/kafka/consumer/CognitiveReportConsumerTest.java
@@ -1,0 +1,69 @@
+package opensource.alzheimerdinger.core.domain.analysis.infra.kafka.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import opensource.alzheimerdinger.core.domain.analysis.application.dto.request.CognitiveReportRequest;
+import opensource.alzheimerdinger.core.domain.analysis.domain.entity.CognitiveReport;
+import opensource.alzheimerdinger.core.domain.analysis.domain.entity.ConversationSession;
+import opensource.alzheimerdinger.core.domain.analysis.domain.repository.CognitiveReportRepository;
+import opensource.alzheimerdinger.core.domain.analysis.domain.repository.ConversationSessionRepository;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@SpringBootTest
+@EmbeddedKafka(partitions = 1, topics = { "cognitive-report" }, brokerProperties = { "listeners=PLAINTEXT://localhost:9092", "port=9092" })
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class CognitiveReportConsumerTest {
+
+    @Autowired KafkaTemplate<String, String> kafkaTemplate;
+    @Autowired ConversationSessionRepository sessionRepo;
+    @Autowired CognitiveReportRepository reportRepo;
+    @Autowired ObjectMapper objectMapper;
+
+    final String SESSION_ID = "session-cog-1";
+
+    @BeforeEach
+    void setUp() {
+        reportRepo.deleteAll();
+        sessionRepo.deleteAll();
+        sessionRepo.save(ConversationSession.builder()
+                .sessionId(SESSION_ID)
+                .userId("user-cog")
+                .startTime(LocalDateTime.now())
+                .endTime(LocalDateTime.now())
+                .sessionSeq(1)
+                .build()
+        );
+    }
+
+    @Test
+    void testConsumeCognitiveReportMessage() throws Exception {
+        CognitiveReportRequest dto = new CognitiveReportRequest();
+        dto.setReportId("report-456");
+        dto.setSessionId(SESSION_ID);
+        dto.setRiskScore(75);
+        dto.setRiskLevel("MEDIUM");
+        dto.setInterpretation("Within normal limits");
+        dto.setCreatedAt(LocalDateTime.of(2025,7,11,15,30));
+
+        String payload = objectMapper.writeValueAsString(dto);
+        kafkaTemplate.send(new ProducerRecord<>("cognitive-report", payload));
+        kafkaTemplate.flush();
+        Thread.sleep(500);
+
+        List<CognitiveReport> saved = reportRepo.findBySession_SessionId(SESSION_ID);
+        assertThat(saved).hasSize(1);
+        var cr = saved.get(0);
+        assertThat(cr.getReportId()).isEqualTo("report-456");
+    }
+}

--- a/src/test/java/opensource/alzheimerdinger/core/domain/analysis/infra/kafka/consumer/EmotionAnalysisConsumerTest.java
+++ b/src/test/java/opensource/alzheimerdinger/core/domain/analysis/infra/kafka/consumer/EmotionAnalysisConsumerTest.java
@@ -1,0 +1,72 @@
+package opensource.alzheimerdinger.core.domain.analysis.infra.kafka.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import opensource.alzheimerdinger.core.domain.analysis.application.dto.request.EmotionAnalysisRequest;
+import opensource.alzheimerdinger.core.domain.analysis.domain.entity.ConversationSession;
+import opensource.alzheimerdinger.core.domain.analysis.domain.entity.EmotionAnalysis;
+import opensource.alzheimerdinger.core.domain.analysis.domain.repository.ConversationSessionRepository;
+import opensource.alzheimerdinger.core.domain.analysis.domain.repository.EmotionAnalysisRepository;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@SpringBootTest
+@EmbeddedKafka(partitions = 1, topics = { "emotion-analysis" }, brokerProperties = { "listeners=PLAINTEXT://localhost:9092", "port=9092" })
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class EmotionAnalysisConsumerTest {
+
+    @Autowired
+    KafkaTemplate<String, String> kafkaTemplate;
+    @Autowired
+    ConversationSessionRepository sessionRepo;
+    @Autowired
+    EmotionAnalysisRepository analysisRepo;
+    @Autowired
+    ObjectMapper objectMapper;
+
+    final String SESSION_ID = "session-emo-1";
+
+    @BeforeEach
+    void setUp() {
+        analysisRepo.deleteAll();
+        sessionRepo.deleteAll();
+        sessionRepo.save(ConversationSession.builder()
+                .sessionId(SESSION_ID)
+                .userId("user-emo")
+                .startTime(LocalDateTime.now())
+                .endTime(LocalDateTime.now())
+                .sessionSeq(1)
+                .build()
+        );
+    }
+
+    @Test
+    void testConsumeEmotionAnalysisMessage() throws Exception {
+        EmotionAnalysisRequest dto = new EmotionAnalysisRequest();
+        dto.setAnalysisId("analysis-123");
+        dto.setSessionId(SESSION_ID);
+        dto.setAnalysisTime(LocalDateTime.of(2025,7,11,14,0));
+        dto.setEmotionLabel("HAPPY");
+        dto.setEmotionScore(0.92f);
+
+        String payload = objectMapper.writeValueAsString(dto);
+        kafkaTemplate.send(new ProducerRecord<>("emotion-analysis", payload));
+        kafkaTemplate.flush();
+        Thread.sleep(500);
+
+        List<EmotionAnalysis> saved = analysisRepo.findBySession_SessionId(SESSION_ID);
+        assertThat(saved).hasSize(1);
+        var ea = saved.get(0);
+        assertThat(ea.getAnalysisId()).isEqualTo("analysis-123");
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL
     driver-class-name: org.h2.Driver
     username: sa
     password:
@@ -20,9 +20,11 @@ spring:
   kafka:
     bootstrap-servers: localhost:9092
     consumer:
-      group-id: transcript-consumer-group
+      group-id: test-analysis-group #transcript-consumer-group
     topics:
       transcript: ai-transcript
+      emotion-analysis: emotion-analysis
+      cognitive-report: cognitive-report
 
 jwt:
   key: fdsafdsafdsafdsafdsafdsafdsafdsafdsafdsafda


### PR DESCRIPTION
## #️⃣ Issue Number

#31 close

## 📝작업 내용

분석 결과를 수신하기 위한 Kafka Consumer 구현
- EmotionAnalysisConsumer : emotion-analysis 토픽 구독 후 EmotionAnalysisService로 전달
- CognitiveReportConsumer : cognitive-report 토픽 구독 후 CognitiveReportService로 전달

Service 레이어 분리 및 RDB 저장 로직 추가
- EmotionAnalysisService.saveEmotionAnalysis(...)
- CognitiveReportService.saveCognitiveReport(...)

H2 인메모리 DB와 Embedded Kafka를 활용한 통합 테스트 추가
- EmotionAnalysisConsumerTest & CognitiveReportConsumerTest
- application.yml(test) 설정으로 spring.kafka.topics 및 spring.kafka.consumer.group-id 정의



## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

(없음)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트 혹은 테스트 코드를 작성했습니다.