### PR TITLE
[FEAT] 프로필 수정 로직 구현

### DIFF
--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/application/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/application/dto/request/UpdateProfileRequest.java
@@ -1,5 +1,6 @@
 package opensource.alzheimerdinger.core.domain.user.application.dto.request;
 
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import opensource.alzheimerdinger.core.domain.user.domain.entity.Gender;
@@ -9,4 +10,10 @@ public record UpdateProfileRequest(
         @NotNull Gender gender,
         String currentPassword,
         String newPassword
-) {}
+) {
+    @AssertTrue(message = "currentPassword is required when newPassword is provided")
+    public boolean isPasswordChangeValid() {
+        if (newPassword == null || newPassword.isBlank()) return true; // 변경 안 함
+        return currentPassword != null && !currentPassword.isBlank();  // 변경 시 현재 비번 필수
+    }
+}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/application/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/application/dto/request/UpdateProfileRequest.java
@@ -1,0 +1,12 @@
+package opensource.alzheimerdinger.core.domain.user.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import opensource.alzheimerdinger.core.domain.user.domain.entity.Gender;
+
+public record UpdateProfileRequest(
+        @NotBlank String name,
+        @NotNull Gender gender,
+        String currentPassword,
+        String newPassword
+) {}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/domain/entity/User.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/domain/entity/User.java
@@ -1,7 +1,6 @@
 package opensource.alzheimerdinger.core.domain.user.domain.entity;
 
 import io.hypersistence.utils.hibernate.id.Tsid;
-import org.springframework.lang.Nullable;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -40,7 +39,7 @@ public class User extends BaseEntity {
     public void updateRole(Role role) {
         this.role = role;
     }
-    public void updateProfile(String name, Gender gender, @Nullable String encodedNewPassword) {
+    public void updateProfile(String name, Gender gender, String encodedNewPassword) {
         this.name = name;
         this.gender = gender;
         if (encodedNewPassword != null && !encodedNewPassword.isBlank()) {

--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/domain/entity/User.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/domain/entity/User.java
@@ -1,6 +1,7 @@
 package opensource.alzheimerdinger.core.domain.user.domain.entity;
 
 import io.hypersistence.utils.hibernate.id.Tsid;
+import org.springframework.lang.Nullable;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -38,5 +39,12 @@ public class User extends BaseEntity {
 
     public void updateRole(Role role) {
         this.role = role;
+    }
+    public void updateProfile(String name, Gender gender, @Nullable String encodedNewPassword) {
+        this.name = name;
+        this.gender = gender;
+        if (encodedNewPassword != null && !encodedNewPassword.isBlank()) {
+            this.password = encodedNewPassword;
+        }
     }
 }

--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/domain/service/UserProfileService.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/domain/service/UserProfileService.java
@@ -1,0 +1,54 @@
+package opensource.alzheimerdinger.core.domain.user.domain.service;
+
+import lombok.RequiredArgsConstructor;
+import opensource.alzheimerdinger.core.domain.user.application.dto.request.UpdateProfileRequest;
+import opensource.alzheimerdinger.core.domain.user.application.dto.response.ProfileResponse;
+import opensource.alzheimerdinger.core.domain.user.domain.entity.User;
+import opensource.alzheimerdinger.core.domain.user.domain.repository.UserRepository;
+import opensource.alzheimerdinger.core.global.exception.RestApiException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static opensource.alzheimerdinger.core.global.exception.code.status.GlobalErrorStatus._NOT_FOUND;
+import static opensource.alzheimerdinger.core.global.exception.code.status.GlobalErrorStatus._UNAUTHORIZED;
+
+@Service
+@RequiredArgsConstructor
+public class UserProfileService {
+    private static final Logger log = LoggerFactory.getLogger(UserProfileService.class);
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public ProfileResponse updateProfile(String userId, UpdateProfileRequest req) {
+        log.debug("[UserProfile] updateProfile start: userId={}", userId);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> {
+                    log.warn("[UserProfile] user not found: userId={}", userId);
+                    return new RestApiException(_NOT_FOUND);
+                });
+
+        String encodedNewPassword = null;
+
+        // 새 비밀번호가 들어온 경우에만 현재 비번 검증 + 해싱
+        if (req.newPassword() != null && !req.newPassword().isBlank()) {
+            if (req.currentPassword() == null || req.currentPassword().isBlank()
+                    || !passwordEncoder.matches(req.currentPassword(), user.getPassword())) {
+                log.warn("[UserProfile] password change failed: userId={} (current mismatch or empty)", userId);
+                throw new RestApiException(_UNAUTHORIZED);
+            }
+            encodedNewPassword = passwordEncoder.encode(req.newPassword());
+        }
+
+        // 엔티티에 값 반영
+        user.updateProfile(req.name(), req.gender(), encodedNewPassword);
+
+        // @Transactional + JPA dirty checking으로 자동 반영
+        log.info("[UserProfile] updateProfile success: userId={}", user.getUserId());
+        return ProfileResponse.create(user);
+    }
+}

--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/ui/UserController.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/ui/UserController.java
@@ -7,14 +7,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import opensource.alzheimerdinger.core.domain.user.application.dto.request.UpdateProfileRequest;
 import opensource.alzheimerdinger.core.domain.user.application.dto.response.ProfileResponse;
 import opensource.alzheimerdinger.core.domain.user.application.usecase.UserProfileUseCase;
+import opensource.alzheimerdinger.core.domain.user.domain.service.UserProfileService;
 import opensource.alzheimerdinger.core.global.annotation.CurrentUser;
 import opensource.alzheimerdinger.core.global.common.BaseResponse;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "User", description = "사용자 프로필 API")
 @RestController
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserProfileUseCase userProfileUseCase;
+    private final UserProfileService userProfileService;
 
     @Operation(
             summary = "프로필 조회",
@@ -35,5 +37,24 @@ public class UserController {
     public BaseResponse<ProfileResponse> getProfile(
             @Parameter(hidden = true) @CurrentUser String userId) {
         return BaseResponse.onSuccess(userProfileUseCase.findProfile(userId));
+    }
+
+    @Operation(
+            summary = "프로필 수정",
+            description = """
+                이름/성별/비밀번호 변경을 지원합니다.
+                - 환자번호(patientCode)는 수정 불가
+                - 비밀번호 변경 시: currentPassword 검증 후 newPassword 저장(BCrypt 해싱)
+                """,
+            responses = @ApiResponse(responseCode = "200", description = "수정 성공",
+                    content = @Content(schema = @Schema(implementation = ProfileResponse.class)))
+    )
+    @PatchMapping("/profile")
+    public BaseResponse<ProfileResponse> updateProfile(
+            @Parameter(hidden = true) @CurrentUser String userId,
+            @Valid @RequestBody UpdateProfileRequest request
+    ) {
+        ProfileResponse updated = userProfileService.updateProfile(userId, request);
+        return BaseResponse.onSuccess(updated);
     }
 }

--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/ui/UserController.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/ui/UserController.java
@@ -13,7 +13,6 @@ import opensource.alzheimerdinger.core.domain.user.application.dto.request.Updat
 import opensource.alzheimerdinger.core.domain.user.application.dto.response.ProfileResponse;
 import opensource.alzheimerdinger.core.domain.user.application.usecase.UpdateProfileUseCase;
 import opensource.alzheimerdinger.core.domain.user.application.usecase.UserProfileUseCase;
-import opensource.alzheimerdinger.core.domain.user.domain.service.UserProfileService;
 import opensource.alzheimerdinger.core.global.annotation.CurrentUser;
 import opensource.alzheimerdinger.core.global.common.BaseResponse;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/opensource/alzheimerdinger/core/domain/user/ui/UserController.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/user/ui/UserController.java
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import opensource.alzheimerdinger.core.domain.user.application.dto.request.UpdateProfileRequest;
 import opensource.alzheimerdinger.core.domain.user.application.dto.response.ProfileResponse;
+import opensource.alzheimerdinger.core.domain.user.application.usecase.UpdateProfileUseCase;
 import opensource.alzheimerdinger.core.domain.user.application.usecase.UserProfileUseCase;
 import opensource.alzheimerdinger.core.domain.user.domain.service.UserProfileService;
 import opensource.alzheimerdinger.core.global.annotation.CurrentUser;
@@ -24,8 +25,8 @@ import org.springframework.web.bind.annotation.*;
 @SecurityRequirement(name = "Bearer Authentication")
 public class UserController {
 
-    private final UserProfileUseCase userProfileUseCase;
-    private final UserProfileService userProfileService;
+    private final UserProfileUseCase userProfileUseCase; // 조회
+    private final UpdateProfileUseCase updateProfileUseCase; // 수정
 
     @Operation(
             summary = "프로필 조회",
@@ -54,7 +55,7 @@ public class UserController {
             @Parameter(hidden = true) @CurrentUser String userId,
             @Valid @RequestBody UpdateProfileRequest request
     ) {
-        ProfileResponse updated = userProfileService.updateProfile(userId, request);
+        ProfileResponse updated = updateProfileUseCase.update(userId, request);
         return BaseResponse.onSuccess(updated);
     }
 }

--- a/src/test/java/opensource/alzheimerdinger/core/domain/user/application/usecase/UpdateProfileUseCaseTest.java
+++ b/src/test/java/opensource/alzheimerdinger/core/domain/user/application/usecase/UpdateProfileUseCaseTest.java
@@ -1,0 +1,144 @@
+package opensource.alzheimerdinger.core.domain.user.application.usecase;
+
+
+import opensource.alzheimerdinger.core.domain.user.application.dto.request.UpdateProfileRequest;
+import opensource.alzheimerdinger.core.domain.user.application.dto.response.ProfileResponse;
+import opensource.alzheimerdinger.core.domain.user.domain.entity.Gender;
+import opensource.alzheimerdinger.core.domain.user.domain.entity.Role;
+import opensource.alzheimerdinger.core.domain.user.domain.entity.User;
+import opensource.alzheimerdinger.core.domain.user.domain.service.UserService;
+import opensource.alzheimerdinger.core.global.exception.RestApiException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static opensource.alzheimerdinger.core.global.exception.code.status.GlobalErrorStatus._UNAUTHORIZED;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateProfileUseCaseTest {
+
+    @Mock
+    private UserService userService;
+    @Mock private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UpdateProfileUseCase useCase;
+
+    private User existing;
+
+    @BeforeEach
+    void setUp() {
+        existing = User.builder()
+                .userId("U1")
+                .name("Old Name")
+                .email("old@example.com")
+                .password("$2a$10$oldhash") // 가짜 해시
+                .role(Role.PATIENT)
+                .gender(Gender.MALE)
+                .build();
+    }
+
+    @Test
+    @DisplayName("이름/성별만 변경: 비번은 그대로 유지")
+    void update_profile_without_password_change() {
+        // given
+        UpdateProfileRequest req = new UpdateProfileRequest(
+                "New Name",
+                Gender.FEMALE,
+                null,     // currentPassword
+                null      // newPassword
+        );
+        when(userService.findUser("U1")).thenReturn(existing);
+
+        // when
+        ProfileResponse res = useCase.update("U1", req);
+
+        // then
+        assertThat(res.name()).isEqualTo("New Name");
+        assertThat(res.gender()).isEqualTo(Gender.FEMALE);
+        assertThat(existing.getPassword()).isEqualTo("$2a$10$oldhash"); // 그대로
+        verify(passwordEncoder, never()).encode(anyString());
+        verify(passwordEncoder, never()).matches(any(), any());
+    }
+
+    @Test
+    @DisplayName("비번 변경: 현재 비번 일치 → 새 비번 해싱 저장")
+    void update_profile_with_password_change_success() {
+        // given
+        UpdateProfileRequest req = new UpdateProfileRequest(
+                "New Name",
+                Gender.FEMALE,
+                "current-plain", // 현재 비번
+                "new-plain"      // 새 비번
+        );
+        when(userService.findUser("U1")).thenReturn(existing);
+        when(passwordEncoder.matches("current-plain", "$2a$10$oldhash")).thenReturn(true);
+        when(passwordEncoder.encode("new-plain")).thenReturn("$2a$10$newhash");
+
+        // when
+        ProfileResponse res = useCase.update("U1", req);
+
+        // then
+        assertThat(res.name()).isEqualTo("New Name");
+        assertThat(res.gender()).isEqualTo(Gender.FEMALE);
+        assertThat(existing.getPassword()).isEqualTo("$2a$10$newhash");
+        verify(passwordEncoder).matches("current-plain", "$2a$10$oldhash");
+        verify(passwordEncoder).encode("new-plain");
+    }
+
+    @Test
+    @DisplayName("비번 변경: 현재 비번 불일치 → UNAUTHORIZED 예외")
+    void update_profile_with_password_change_mismatch() {
+        // given
+        UpdateProfileRequest req = new UpdateProfileRequest(
+                "New Name",
+                Gender.FEMALE,
+                "wrong-current",
+                "new-plain"
+        );
+        when(userService.findUser("U1")).thenReturn(existing);
+        when(passwordEncoder.matches("wrong-current", "$2a$10$oldhash")).thenReturn(false);
+
+        // when / then
+        assertThatThrownBy(() -> useCase.update("U1", req))
+                .isInstanceOf(RestApiException.class)
+                .satisfies(ex -> {
+                    RestApiException e = (RestApiException) ex;
+                    // 401 (UNAUTHORIZED)
+                    assertThat(e.getErrorCode().getHttpStatus().value()).isEqualTo(401);
+                    // 프로젝트 통일 코드라면 (예: COMMON401)
+                    assertThat(e.getErrorCode().getCode()).isEqualTo("COMMON401");
+                });
+
+        // 비번은 그대로
+        assertThat(existing.getPassword()).isEqualTo("$2a$10$oldhash");
+        verify(passwordEncoder, never()).encode(anyString());
+    }
+
+    @Test
+    @DisplayName("UserService에서 _NOT_FOUND 던질 때 그대로 전파")
+    void user_not_found_bubbles_up() {
+        // given
+        UpdateProfileRequest req = new UpdateProfileRequest(
+                "New Name",
+                Gender.FEMALE,
+                null,
+                null
+        );
+        when(userService.findUser("U2")).thenThrow(new RestApiException(
+                opensource.alzheimerdinger.core.global.exception.code.status.GlobalErrorStatus._NOT_FOUND
+        ));
+
+        // when / then
+        assertThatThrownBy(() -> useCase.update("U2", req))
+                .isInstanceOf(RestApiException.class);
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

#74 

## 📝작업 내용

프로필 수정 코드 구현
- 엔티티 (User) : 엄데이트 전용 메서드 추가
- 요청 DTO (UpdateProfileRequest) 추가
- 서비스 -> 로드 -> 검증 -> 해싱 -> 엔티티 업데이트 (더티체킹)
- 컨트롤러 업데이트 controller 구현

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트 혹은 테스트 코드를 작성했습니다.