### PR TITLE
[REFACTOR] 분석 API 일/월 응답 분리 및 월간 엔드포인트 추가

### DIFF
--- a/src/main/java/opensource/alzheimerdinger/core/domain/analysis/application/dto/response/AnalysisDayResponse.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/analysis/application/dto/response/AnalysisDayResponse.java
@@ -1,23 +1,16 @@
 package opensource.alzheimerdinger.core.domain.analysis.application.dto.response;
 
 import java.time.LocalDate;
-import java.util.List;
 
 public record AnalysisDayResponse(
         String userId,
         LocalDate analysisDate,
+        boolean hasData,
         
         Double happyScore,
         Double sadScore,
         Double angryScore,
         Double surprisedScore,
-        Double boredScore,
-        
-        List<EmotionSummary> monthlyEmotionData
+        Double boredScore
 ) {
-    
-    public record EmotionSummary(
-            LocalDate date,
-            String emotionType
-    ) {}
 }

--- a/src/main/java/opensource/alzheimerdinger/core/domain/analysis/application/dto/response/AnalysisMonthlyResponse.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/analysis/application/dto/response/AnalysisMonthlyResponse.java
@@ -1,0 +1,17 @@
+package opensource.alzheimerdinger.core.domain.analysis.application.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record AnalysisMonthlyResponse(
+        String userId,
+        LocalDate month,
+        List<EmotionSummary> monthlyEmotionData
+) {
+    public record EmotionSummary(
+            LocalDate date,
+            String emotionType
+    ) {}
+}
+
+

--- a/src/main/java/opensource/alzheimerdinger/core/domain/analysis/application/usecase/AnalysisUseCase.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/analysis/application/usecase/AnalysisUseCase.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import opensource.alzheimerdinger.core.domain.analysis.application.dto.response.AnalysisResponse;
 import opensource.alzheimerdinger.core.domain.analysis.application.dto.response.AnalysisDayResponse;
 import opensource.alzheimerdinger.core.domain.analysis.application.dto.response.AnalysisReportResponse;
+import opensource.alzheimerdinger.core.domain.analysis.application.dto.response.AnalysisMonthlyResponse;
 import opensource.alzheimerdinger.core.domain.analysis.domain.entity.AnalysisReport;
 import opensource.alzheimerdinger.core.domain.analysis.domain.service.AnalysisService;
 import opensource.alzheimerdinger.core.global.metric.UseCaseMetric;
@@ -31,6 +32,12 @@ public class AnalysisUseCase {
     @UseCaseMetric(domain = "analysis", value = "get-day", type = "query")
     public AnalysisDayResponse getAnalysisDayData(String userId, LocalDate date) {
         return analysisService.getDayData(userId, date);
+    }
+
+    // 월간 달력용 데이터 조회
+    @UseCaseMetric(domain = "analysis", value = "get-month", type = "query")
+    public AnalysisMonthlyResponse getAnalysisMonthlyData(String userId, LocalDate date) {
+        return analysisService.getMonthlyData(userId, date);
     }
 
     //기존 분석 리포트 중 가장 최근 리포트 조회

--- a/src/main/java/opensource/alzheimerdinger/core/domain/analysis/domain/service/AnalysisService.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/analysis/domain/service/AnalysisService.java
@@ -3,6 +3,7 @@ package opensource.alzheimerdinger.core.domain.analysis.domain.service;
 import lombok.RequiredArgsConstructor;
 import opensource.alzheimerdinger.core.domain.analysis.application.dto.response.AnalysisResponse;
 import opensource.alzheimerdinger.core.domain.analysis.application.dto.response.AnalysisDayResponse;
+import opensource.alzheimerdinger.core.domain.analysis.application.dto.response.AnalysisMonthlyResponse;
 import opensource.alzheimerdinger.core.domain.analysis.domain.entity.EmotionAnalysis;
 import opensource.alzheimerdinger.core.domain.analysis.domain.entity.AnalysisReport;
 import opensource.alzheimerdinger.core.domain.analysis.domain.entity.DementiaAnalysis;
@@ -105,29 +106,40 @@ public class AnalysisService {
         List<EmotionAnalysis> dayAnalyses = findEmotionAnalysisData(userId, startOfDay, endOfDay);
         
         if (dayAnalyses.isEmpty()) {
-            throw new RestApiException(_NOT_FOUND);
+            return new AnalysisDayResponse(
+                    userId,
+                    date,
+                    false,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+            );
         }
 
         EmotionAnalysis latestAnalysis = dayAnalyses.get(dayAnalyses.size() - 1);
-        
-        //월간 데이터 생성 (달력용 - 해당 월의 모든 일별 요약)
-        List<AnalysisDayResponse.EmotionSummary> monthlyData = getMonthlyEmotion(userId, date);
 
         return new AnalysisDayResponse(
                 userId,
                 date,
+                true,
                 latestAnalysis.getHappy(),
                 latestAnalysis.getSad(),
                 latestAnalysis.getAngry(),
                 latestAnalysis.getSurprised(),
-                latestAnalysis.getBored(),
-                monthlyData
+                latestAnalysis.getBored()
         );
     }
 
-     //달력 UI용 월간 감정 요약 데이터 생성
+    // 달력 UI용 월간 감정 요약 데이터 생성 (데이터가 없어도 빈 리스트로 반환)
+    public AnalysisMonthlyResponse getMonthlyData(String userId, LocalDate date) {
+        List<AnalysisMonthlyResponse.EmotionSummary> monthlyData = getMonthlyEmotion(userId, date);
+        LocalDate normalizedMonth = date.withDayOfMonth(1);
+        return new AnalysisMonthlyResponse(userId, normalizedMonth, monthlyData);
+    }
 
-    private List<AnalysisDayResponse.EmotionSummary> getMonthlyEmotion(String userId, LocalDate date) {
+    private List<AnalysisMonthlyResponse.EmotionSummary> getMonthlyEmotion(String userId, LocalDate date) {
         // 해당 월의 첫날과 마지막날 계산
         LocalDateTime startOfMonth = date.withDayOfMonth(1).atStartOfDay();
         LocalDateTime endOfMonth = date.withDayOfMonth(date.lengthOfMonth()).atTime(23, 59, 59);
@@ -149,7 +161,7 @@ public class AnalysisService {
                     EmotionAnalysis lastAnalysisOfDay = dailyAnalyses.get(dailyAnalyses.size() - 1);
                     String mainEmotion = getMainEmotion(lastAnalysisOfDay);
                     
-                    return new AnalysisDayResponse.EmotionSummary(
+                    return new AnalysisMonthlyResponse.EmotionSummary(
                             dailyDate,
                             mainEmotion
                     );

--- a/src/main/java/opensource/alzheimerdinger/core/domain/analysis/ui/AnalysisController.java
+++ b/src/main/java/opensource/alzheimerdinger/core/domain/analysis/ui/AnalysisController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import opensource.alzheimerdinger.core.domain.analysis.application.dto.response.AnalysisResponse;
 import opensource.alzheimerdinger.core.domain.analysis.application.dto.response.AnalysisDayResponse;
 import opensource.alzheimerdinger.core.domain.analysis.application.dto.response.AnalysisReportResponse;
+import opensource.alzheimerdinger.core.domain.analysis.application.dto.response.AnalysisMonthlyResponse;
 import opensource.alzheimerdinger.core.domain.analysis.application.usecase.AnalysisUseCase;
 import opensource.alzheimerdinger.core.global.annotation.CurrentUser;
 import opensource.alzheimerdinger.core.global.common.BaseResponse;
@@ -57,15 +58,14 @@ public class AnalysisController {
      //일별 감정 분석 데이터 조회 (달력용)     
     @Operation(
             summary = "일별 감정 분석 조회",
-            description = "특정 날짜의 감정 분석 데이터와 달력 표시용 월간 데이터를 반환합니다.",
+            description = "특정 날짜의 감정 분석 데이터를 반환합니다. 데이터가 없으면 hasData=false와 빈 값으로 응답합니다.",
             parameters = {
                     @Parameter(name = "date", description = "조회할 날짜 (YYYY-MM-DD)", required = true, example = "2024-01-15")
             },
             responses = {
                     @ApiResponse(responseCode = "200", description = "조회 성공",
                             content = @Content(schema = @Schema(implementation = AnalysisDayResponse.class))),
-                    @ApiResponse(responseCode = "400", description = "잘못된 날짜 형식", content = @Content),
-                    @ApiResponse(responseCode = "404", description = "데이터 없음", content = @Content)
+                    @ApiResponse(responseCode = "400", description = "잘못된 날짜 형식", content = @Content)
             }
     )
     @GetMapping("/day")
@@ -73,6 +73,26 @@ public class AnalysisController {
             @CurrentUser String userId, 
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @NotNull LocalDate date) {
         return BaseResponse.onSuccess(analysisUseCase.getAnalysisDayData(userId, date));
+    }
+
+    // 월간 감정 분석 요약 (달력용)
+    @Operation(
+            summary = "월간 감정 요약 조회",
+            description = "달력 표시용 월간 감정 요약 데이터를 반환합니다. 데이터가 없으면 빈 배열을 반환합니다.",
+            parameters = {
+                    @Parameter(name = "month", description = "조회 기준 날짜 (해당 달을 의미, YYYY-MM-DD)", required = true, example = "2024-01-15")
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공",
+                            content = @Content(schema = @Schema(implementation = AnalysisMonthlyResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "잘못된 날짜 형식", content = @Content)
+            }
+    )
+    @GetMapping("/month")
+    public BaseResponse<AnalysisMonthlyResponse> getMonthlyAnalysis(
+            @CurrentUser String userId,
+            @RequestParam("month") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @NotNull LocalDate month) {
+        return BaseResponse.onSuccess(analysisUseCase.getAnalysisMonthlyData(userId, month));
     }
 
     


### PR DESCRIPTION
## #️⃣ Issue Number

#85 
## 📝작업 내용

- 일/월 응답 분리: AnalysisDayResponse(일간) / AnalysisMonthlyResponse(월간)
- 엔드포인트 추가: GET /api/analysis/month?month=YYYY-MM-DD
- 일간 응답 정책 변경: 데이터 없으면 200 + hasData=false로 빈 값 반환
- 컨트롤러/유스케이스/서비스 전반 리팩토링

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트 혹은 테스트 코드를 작성했습니다.