### PR TITLE
[FEAT] 통합 보고서 평균 통화 시간 Transcript 기반 계산 및 반환 로직 구현

### DIFF
--- a/src/test/java/opensource/alzheimerdinger/core/domain/relation/application/usecase/RelationManagementUseCaseTest.java
+++ b/src/test/java/opensource/alzheimerdinger/core/domain/relation/application/usecase/RelationManagementUseCaseTest.java
@@ -141,7 +141,7 @@ class RelationManagementUseCaseTest {
         when(relation.getRelationStatus()).thenReturn(RelationStatus.DISCONNECTED);
         when(relation.isMember(user)).thenReturn(false);
 
-        RelationReconnectRequest req = new RelationReconnectRequest(relationId, "guardianId");
+        RelationReconnectRequest req = new RelationReconnectRequest(relationId);
         relationManagementUseCase.resend(user.getUserId(), req);
 
         verify(relation).resend(user.getUserId());
@@ -154,7 +154,7 @@ class RelationManagementUseCaseTest {
         when(relationService.findRelation("r1")).thenReturn(relation);
         when(relation.getRelationStatus()).thenReturn(RelationStatus.ACCEPTED);
 
-        RelationReconnectRequest req = new RelationReconnectRequest("r1", "guardianId");
+        RelationReconnectRequest req = new RelationReconnectRequest("r1");
 
         Throwable thrown = catchThrowable(() ->
                 relationManagementUseCase.resend("g1", req)
@@ -172,7 +172,7 @@ class RelationManagementUseCaseTest {
         when(relation.getRelationStatus()).thenReturn(RelationStatus.DISCONNECTED);
         when(relation.isMember(any(User.class))).thenReturn(true);
 
-        RelationReconnectRequest req = new RelationReconnectRequest("r1", "guardianId");
+        RelationReconnectRequest req = new RelationReconnectRequest("r1");
 
         Throwable thrown = catchThrowable(() ->
                 relationManagementUseCase.resend("g1", req)


### PR DESCRIPTION
## #️⃣ Issue Number

#87 
## 📝작업 내용

- 통합 보고서 평균 통화 시간 하드코딩 제거 → Transcript 기반 기간 평균으로 계산해 반환
- 유효성 필터링(누락/역전된 시간 제외), 평균 반올림, 한국어 포맷(H시간 M분 S초/M분 S초/S초)
- AnalysisService에 TranscriptRepository 주입 및 유틸 메서드 추가
- 분석 서비스/유즈케이스 테스트 보강 및 필요한 테스트 정리 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트 혹은 테스트 코드를 작성했습니다.